### PR TITLE
chore!: Drop support for ember-source@3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,7 @@ jobs:
     strategy:
       matrix:
         # Keep this in sync with config/ember-try.js
-        ember:
-          [ember-3.13, ember-lts-3.16, ember-release, ember-beta, ember-canary]
+        ember: [ember-lts-3.16, ember-release, ember-beta, ember-canary]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Based on [every-layout.dev](https://every-layout.dev/).
 
 ## Compatibility
 
-- Ember.js v3.13 or above (Requires Octane!)
+- Ember.js v3.16 or above
 - Ember CLI v2.13 or above
 - Node.js v10 or above
 
@@ -43,11 +43,11 @@ For more details, see the [documentation](https://fabscale.github.io/ember-layou
 
 ## Available layout components
 
-* `<Layout::Wrapper>`
-* `<Layout::Center>`
-* `<Layout::VerticalStack>`
-* `<Layout::Cluster>`
-* `<Layout::Grid>`
+- `<Layout::Wrapper>`
+- `<Layout::Center>`
+- `<Layout::VerticalStack>`
+- `<Layout::Cluster>`
+- `<Layout::Grid>`
 
 ## Contributing
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,14 +7,6 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-3.13',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.13.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-3.16',
         npm: {
           devDependencies: {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ember-prism": "^0.6.0",
     "ember-qunit": "~4.6.0",
     "ember-resolver": "~7.0.0",
-    "ember-source": "~3.17.0",
+    "ember-source": "~3.17.3",
     "ember-source-channel-url": "~2.0.1",
     "ember-template-lint": "~2.4.0",
     "ember-try": "~1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -172,7 +172,7 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
-"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.8.3":
+"@babel/helper-module-imports@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz#7fe39589b39c016331b6b8c3f441e8f0b1419498"
   integrity sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==
@@ -480,7 +480,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-transform-block-scoping@^7.6.2", "@babel/plugin-transform-block-scoping@^7.8.3":
+"@babel/plugin-transform-block-scoping@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.8.3.tgz#97d35dab66857a437c166358b91d09050c868f3a"
   integrity sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==
@@ -619,7 +619,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-transform-object-assign@^7.2.0":
+"@babel/plugin-transform-object-assign@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.8.3.tgz#dc3b8dd50ef03837868a37b7df791f64f288538e"
   integrity sha512-i3LuN8tPDqUCRFu3dkzF2r1Nx0jp4scxtm7JxtIqI9he9Vk20YD+/zshdzR9JLsoBMlJlNR82a62vQExNEVx/Q==
@@ -5311,14 +5311,14 @@ ember-source-channel-url@^2.0.1, ember-source-channel-url@~2.0.1:
   dependencies:
     got "^8.0.1"
 
-ember-source@~3.17.0:
-  version "3.17.0"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.17.0.tgz#6365b8e43f72d552f62e5d7ee4e841595ae70579"
-  integrity sha512-CfOi00tYGdwR12FuBMuiBzyC4cmabHtkL+LpORWavCRHN0UfBpBTj64rmKMD2HNJhYZFVX+8ZFTO27FX8D6Glg==
+ember-source@~3.17.3:
+  version "3.17.3"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.17.3.tgz#315b198848bcc1699928579b2d7fc2d607ebf63e"
+  integrity sha512-mZ2a4MRJm+QsZ61q7p4Ulq+07IERgEF7mEzOPmqES+J4PpeXyWHAYh1MnSWHz3W5jQhwHQAPs6WTZE0TbAsS2Q==
   dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@babel/plugin-transform-block-scoping" "^7.6.2"
-    "@babel/plugin-transform-object-assign" "^7.2.0"
+    "@babel/helper-module-imports" "^7.8.3"
+    "@babel/plugin-transform-block-scoping" "^7.8.3"
+    "@babel/plugin-transform-object-assign" "^7.8.3"
     "@ember/edition-utils" "^1.2.0"
     babel-plugin-debug-macros "^0.3.3"
     babel-plugin-filter-imports "^4.0.0"
@@ -5327,7 +5327,7 @@ ember-source@~3.17.0:
     broccoli-funnel "^2.0.2"
     broccoli-merge-trees "^3.0.2"
     chalk "^3.0.0"
-    ember-cli-babel "^7.13.2"
+    ember-cli-babel "^7.18.0"
     ember-cli-get-component-path-option "^1.0.0"
     ember-cli-is-package-missing "^1.0.0"
     ember-cli-normalize-entity-name "^1.0.0"


### PR DESCRIPTION
This is not supported by newer ember-cli-babel versions anymore.

BREAKING CHANGEL: Changed support