### PR TITLE
feat: Allow to specify @vertical & @horizontal for <Layout::Center>

### DIFF
--- a/addon/components/layout/center.hbs
+++ b/addon/components/layout/center.hbs
@@ -1,5 +1,10 @@
 <div
-  class="layout-center"
+  class={{
+    layout-join-classes
+    'layout-center'
+    (layout-class-if @horizontal false '' 'layout-center--horizontal')
+    (layout-class-if @vertical true 'layout-center--vertical')
+  }}
   ...attributes
 >
   {{yield}}

--- a/addon/helpers/layout-class-if.js
+++ b/addon/helpers/layout-class-if.js
@@ -4,6 +4,7 @@ export default helper(function layoutClassIf([
   variable,
   compareValue,
   className,
+  classNameElse = '',
 ]) {
-  return variable === compareValue ? className : '';
+  return variable === compareValue ? className : classNameElse;
 });

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -23,7 +23,16 @@
   width: auto;
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
+}
+
+.layout-center--horizontal {
   align-items: center;
+}
+
+.layout-center--vertical {
+  height: 100%;
+  justify-content: center;
 }
 
 /* Vertical Stack */

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -8,6 +8,8 @@ export default class ApplicationController extends Controller {
   @tracked clusterFullWidthOnMobile;
   @tracked verticalStackSize;
   @tracked verticalStackWithSeparator;
+  @tracked centerHorizontal;
+  @tracked centerVertical;
 
   @action
   updateProperty(property, value) {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -71,13 +71,42 @@
       </SectionItem>
 
       <SectionItem>
+        <Layout::Cluster @fullWidthOnMobile={{true}} as |Item|>
+          <Item>
+            <ConfigOption
+              @label='@horizontal'
+              @value={{this.centerHorizontal}}
+              @onChange={{fn this.updateProperty 'centerHorizontal'}}
+              @options={{array false}}
+            />
+          </Item>
+
+          <Item>
+            <ConfigOption
+              @label='@vertical'
+              @value={{this.centerVertical}}
+              @onChange={{fn this.updateProperty 'centerVertical'}}
+              @options={{array true}}
+            />
+          </Item>
+        </Layout::Cluster>
+      </SectionItem>
+
+      <SectionItem>
         <CodeBlock @code={{this.centerCode}} @language='handlebars' />
       </SectionItem>
 
       <SectionItem>
-        <Layout::Center>
-          <DemoItem />
-        </Layout::Center>
+        {{! template-lint-disable no-inline-styles }}
+        <div style='height: 300px; background: lightgrey;'>
+          <Layout::Center
+            @horizontal={{this.centerHorizontal}}
+            @vertical={{this.centerVertical}}
+          >
+            <DemoItem />
+          </Layout::Center>
+        </div>
+        {{! template-lint-enable no-inline-styles }}
       </SectionItem>
     </Layout::VerticalStack>
   </Section>


### PR DESCRIPTION
This makes it possible to also center stuff vertically. 
By default, it will center horizontally but not vertically.

![Screenshot from 2020-09-07 16-59-56](https://user-images.githubusercontent.com/2411343/92400081-98f06300-f12b-11ea-819f-4eece161ed57.png)
