### PR TITLE
Allow to specify `@noWrap={{true}}` for `<Layout::Cluster>`

### DIFF
--- a/addon/components/layout/cluster.hbs
+++ b/addon/components/layout/cluster.hbs
@@ -8,6 +8,7 @@
     (layout-class-if @size "large" "layout-cluster--large")
     (layout-class-if @size "xlarge" "layout-cluster--xlarge")
     (layout-class-if @fullWidthOnMobile true "layout-cluster--full-width-on-mobile")
+    (layout-class-if @noWrap true "layout-cluster--no-wrap")
   }}
   ...attributes
 >

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -82,6 +82,10 @@
   overflow: hidden;
 }
 
+.layout-cluster--no-wrap {
+  flex-wrap: nowrap;
+}
+
 .layout-cluster-item {
   margin: var(--cluster-half-gap);
 }

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -6,6 +6,7 @@ export default class ApplicationController extends Controller {
   @tracked clusterSize;
   @tracked clusterPosition;
   @tracked clusterFullWidthOnMobile;
+  @tracked clusterNoWrap;
   @tracked verticalStackSize;
   @tracked verticalStackWithSeparator;
   @tracked centerHorizontal;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -60,97 +60,6 @@
     <Layout::VerticalStack as |SectionItem|>
       <SectionItem>
         <h2>
-          Center
-        </h2>
-      </SectionItem>
-
-      <SectionItem>
-        <p>
-          Horizontally center content at it's intrinsic size.
-        </p>
-      </SectionItem>
-
-      <SectionItem>
-        <Layout::Cluster @fullWidthOnMobile={{true}} as |Item|>
-          <Item>
-            <ConfigOption
-              @label='@horizontal'
-              @value={{this.centerHorizontal}}
-              @onChange={{fn this.updateProperty 'centerHorizontal'}}
-              @options={{array false}}
-            />
-          </Item>
-
-          <Item>
-            <ConfigOption
-              @label='@vertical'
-              @value={{this.centerVertical}}
-              @onChange={{fn this.updateProperty 'centerVertical'}}
-              @options={{array true}}
-            />
-          </Item>
-        </Layout::Cluster>
-      </SectionItem>
-
-      <SectionItem>
-        <CodeBlock @code={{this.centerCode}} @language='handlebars' />
-      </SectionItem>
-
-      <SectionItem>
-        {{! template-lint-disable no-inline-styles }}
-        <div style='height: 300px; background: lightgrey;'>
-          <Layout::Center
-            @horizontal={{this.centerHorizontal}}
-            @vertical={{this.centerVertical}}
-          >
-            <DemoItem />
-          </Layout::Center>
-        </div>
-        {{! template-lint-enable no-inline-styles }}
-      </SectionItem>
-    </Layout::VerticalStack>
-  </Section>
-
-  <Section>
-    <Layout::VerticalStack as |SectionItem|>
-      <SectionItem>
-        <h2>
-          Wrapper
-        </h2>
-      </SectionItem>
-
-      <SectionItem>
-        <p>
-          A wrapper that will reach the maximum wrapper size (or smaller), keeping horizontal spacing at any time.
-          Can be customized with
-          <CodeInline @code='--layout-wrapper-width' />
-
-          (default:
-          <CodeInline @code='60rem' />
-          ) and
-          <CodeInline @code='--layout-wrapper-spacing' />
-          (default:
-          <CodeInline @code='2rem' />
-          ).
-        </p>
-      </SectionItem>
-
-      <SectionItem>
-        <CodeBlock @code={{this.wrapperCode}} @language='handlebars' />
-      </SectionItem>
-
-      <SectionItem>
-        <Layout::Wrapper>
-          <DemoItem />
-        </Layout::Wrapper>
-      </SectionItem>
-    </Layout::VerticalStack>
-  </Section>
-
-  <Section>
-    <Layout::VerticalStack as |SectionItem|>
-      <SectionItem>
-        <h2>
           Vertical Stack
         </h2>
       </SectionItem>
@@ -421,6 +330,97 @@
             <DemoItem />
           </Item>
         </Layout::Grid>
+      </SectionItem>
+    </Layout::VerticalStack>
+  </Section>
+
+  <Section>
+    <Layout::VerticalStack as |SectionItem|>
+      <SectionItem>
+        <h2>
+          Center
+        </h2>
+      </SectionItem>
+
+      <SectionItem>
+        <p>
+          Horizontally center content at it's intrinsic size.
+        </p>
+      </SectionItem>
+
+      <SectionItem>
+        <Layout::Cluster @fullWidthOnMobile={{true}} as |Item|>
+          <Item>
+            <ConfigOption
+              @label='@horizontal'
+              @value={{this.centerHorizontal}}
+              @onChange={{fn this.updateProperty 'centerHorizontal'}}
+              @options={{array false}}
+            />
+          </Item>
+
+          <Item>
+            <ConfigOption
+              @label='@vertical'
+              @value={{this.centerVertical}}
+              @onChange={{fn this.updateProperty 'centerVertical'}}
+              @options={{array true}}
+            />
+          </Item>
+        </Layout::Cluster>
+      </SectionItem>
+
+      <SectionItem>
+        <CodeBlock @code={{this.centerCode}} @language='handlebars' />
+      </SectionItem>
+
+      <SectionItem>
+        {{! template-lint-disable no-inline-styles }}
+        <div style='height: 300px; background: lightgrey;'>
+          <Layout::Center
+            @horizontal={{this.centerHorizontal}}
+            @vertical={{this.centerVertical}}
+          >
+            <DemoItem />
+          </Layout::Center>
+        </div>
+        {{! template-lint-enable no-inline-styles }}
+      </SectionItem>
+    </Layout::VerticalStack>
+  </Section>
+
+  <Section>
+    <Layout::VerticalStack as |SectionItem|>
+      <SectionItem>
+        <h2>
+          Wrapper
+        </h2>
+      </SectionItem>
+
+      <SectionItem>
+        <p>
+          A wrapper that will reach the maximum wrapper size (or smaller), keeping horizontal spacing at any time.
+          Can be customized with
+          <CodeInline @code='--layout-wrapper-width' />
+
+          (default:
+          <CodeInline @code='60rem' />
+          ) and
+          <CodeInline @code='--layout-wrapper-spacing' />
+          (default:
+          <CodeInline @code='2rem' />
+          ).
+        </p>
+      </SectionItem>
+
+      <SectionItem>
+        <CodeBlock @code={{this.wrapperCode}} @language='handlebars' />
+      </SectionItem>
+
+      <SectionItem>
+        <Layout::Wrapper>
+          <DemoItem />
+        </Layout::Wrapper>
       </SectionItem>
     </Layout::VerticalStack>
   </Section>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -274,6 +274,15 @@
               @options={{array true}}
             />
           </Item>
+
+          <Item>
+            <ConfigOption
+              @label='@noWrap'
+              @value={{this.clusterNoWrap}}
+              @onChange={{fn this.updateProperty 'clusterNoWrap'}}
+              @options={{array true}}
+            />
+          </Item>
         </Layout::Cluster>
       </SectionItem>
 
@@ -281,7 +290,8 @@
         <Layout::Cluster
           @size={{this.clusterSize}}
           @position={{this.clusterPosition}}
-          @fullWidthOnMobile={{this.clusterFullWidthOnMobile}} as |Item|
+          @fullWidthOnMobile={{this.clusterFullWidthOnMobile}}
+          @noWrap={{this.clusterNoWrap}} as |Item|
         >
           <Item>
             <DemoItem />

--- a/tests/integration/components/layout/cluster-test.js
+++ b/tests/integration/components/layout/cluster-test.js
@@ -86,22 +86,78 @@ module('Integration | Component | layout/cluster', function (hooks) {
   });
 
   module('@fullWidthOnMobile', function () {
-    [
-      {
-        fullWidthOnMobile: true,
-        className: 'layout-cluster--full-width-on-mobile',
-      },
-    ].forEach((scenario) => {
-      test(`it works with ${scenario.fullWidthOnMobile}`, async function (assert) {
-        this.fullWidthOnMobile = scenario.fullWidthOnMobile;
+    test(`it works with undefined`, async function (assert) {
+      this.fullWidthOnMobile = undefined;
 
-        await render(hbs`
-          <Layout::Cluster @fullWidthOnMobile={{this.fullWidthOnMobile}}>
-          </Layout::Cluster>
-        `);
+      await render(hbs`
+        <Layout::Cluster @fullWidthOnMobile={{this.fullWidthOnMobile}}>
+        </Layout::Cluster>
+      `);
 
-        assert.dom('.layout-cluster').hasClass(scenario.className);
-      });
+      assert
+        .dom('.layout-cluster')
+        .doesNotHaveClass('layout-cluster--full-width-on-mobile');
+    });
+
+    test(`it works with false`, async function (assert) {
+      this.fullWidthOnMobile = false;
+
+      await render(hbs`
+        <Layout::Cluster @fullWidthOnMobile={{this.fullWidthOnMobile}}>
+        </Layout::Cluster>
+      `);
+
+      assert
+        .dom('.layout-cluster')
+        .doesNotHaveClass('layout-cluster--full-width-on-mobile');
+    });
+
+    test(`it works with true`, async function (assert) {
+      this.fullWidthOnMobile = true;
+
+      await render(hbs`
+        <Layout::Cluster @fullWidthOnMobile={{this.fullWidthOnMobile}}>
+        </Layout::Cluster>
+      `);
+
+      assert
+        .dom('.layout-cluster')
+        .hasClass('layout-cluster--full-width-on-mobile');
+    });
+  });
+
+  module('@noWrap', function () {
+    test(`it works with undefined`, async function (assert) {
+      this.noWrap = undefined;
+
+      await render(hbs`
+        <Layout::Cluster @noWrap={{this.noWrap}}>
+        </Layout::Cluster>
+      `);
+
+      assert.dom('.layout-cluster').doesNotHaveClass('layout-cluster--no-wrap');
+    });
+
+    test(`it works with false`, async function (assert) {
+      this.noWrap = false;
+
+      await render(hbs`
+        <Layout::Cluster @noWrap={{this.noWrap}}>
+        </Layout::Cluster>
+      `);
+
+      assert.dom('.layout-cluster').doesNotHaveClass('layout-cluster--no-wrap');
+    });
+
+    test(`it works with true`, async function (assert) {
+      this.noWrap = true;
+
+      await render(hbs`
+        <Layout::Cluster @noWrap={{this.noWrap}}>
+        </Layout::Cluster>
+      `);
+
+      assert.dom('.layout-cluster').hasClass('layout-cluster--no-wrap');
     });
   });
 });


### PR DESCRIPTION
This ensures the cluster items always stay on one line.