### PR TITLE
fix: Introduce wrapper element for cluster to avoid scrollbars

### DIFF
--- a/addon/components/layout/cluster.hbs
+++ b/addon/components/layout/cluster.hbs
@@ -1,20 +1,23 @@
-<div
-  class={{layout-join-classes
-    'layout-cluster'
-    (layout-class-if @position "right" "layout-cluster--right")
-    (layout-class-if @position "spaced" "layout-cluster--spaced")
-    (layout-class-if @size "xsmall" "layout-cluster--xsmall")
-    (layout-class-if @size "small" "layout-cluster--small")
-    (layout-class-if @size "large" "layout-cluster--large")
-    (layout-class-if @size "xlarge" "layout-cluster--xlarge")
-    (layout-class-if @fullWidthOnMobile true "layout-cluster--full-width-on-mobile")
-    (layout-class-if @noWrap true "layout-cluster--no-wrap")
-    (layout-class-if @verticalAlign "top" "layout-cluster--top")
-    (layout-class-if @verticalAlign "bottom" "layout-cluster--bottom")
-  }}
-  ...attributes
->
-  {{yield
-    (component 'layout/cluster/item')
-  }}
+<div class='layout-cluster-wrapper'>
+  <div
+    class={{
+      layout-join-classes
+      'layout-cluster'
+      (layout-class-if @position 'right' 'layout-cluster--right')
+      (layout-class-if @position 'spaced' 'layout-cluster--spaced')
+      (layout-class-if @size 'xsmall' 'layout-cluster--xsmall')
+      (layout-class-if @size 'small' 'layout-cluster--small')
+      (layout-class-if @size 'large' 'layout-cluster--large')
+      (layout-class-if @size 'xlarge' 'layout-cluster--xlarge')
+      (layout-class-if
+        @fullWidthOnMobile true 'layout-cluster--full-width-on-mobile'
+      )
+      (layout-class-if @noWrap true 'layout-cluster--no-wrap')
+      (layout-class-if @verticalAlign 'top' 'layout-cluster--top')
+      (layout-class-if @verticalAlign 'bottom' 'layout-cluster--bottom')
+    }}
+    ...attributes
+  >
+    {{yield (component 'layout/cluster/item')}}
+  </div>
 </div>

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -69,17 +69,22 @@
 }
 
 /* Cluster */
+.layout-cluster-wrapper {
+  /* ↓ Suppress horizontal scrolling caused by the negative margin in some circumstances */
+  overflow: hidden;
+}
+
+/* Without this, the overflow: hidden; would not work, sometimes showing unexpected scrollbars... */
 .layout-cluster {
   --cluster-gap-size: var(--layout-cluster-gap);
-  --cluster-half-gap: calc(var(--cluster-gap-size) / 2);
+  --cluster-horizontal-gap: calc(var(--cluster-gap-size) / 2);
+  --cluster-vertical-gap: calc(var(--cluster-gap-size) / 2);
 
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  margin: calc(var(--cluster-half-gap) * -1) calc(var(--cluster-half-gap) * -1);
-
-  /* ↓ Suppress horizontal scrolling caused by the negative margin in some circumstances */
-  overflow: hidden;
+  margin: calc(var(--cluster-vertical-gap) * -1)
+    calc(var(--cluster-horizontal-gap) * -1);
 }
 
 .layout-cluster--no-wrap {
@@ -87,7 +92,7 @@
 }
 
 .layout-cluster-item {
-  margin: var(--cluster-half-gap);
+  margin: var(--cluster-vertical-gap) var(--cluster-horizontal-gap);
 }
 
 .layout-cluster--right {

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -76,7 +76,6 @@ p {
   padding: 1rem;
   background: var(--primary-color);
   color: #fff;
-  overflow-x: hidden;
 }
 
 .header-logo-link {


### PR DESCRIPTION
This introduces a wrapper element for `<Layout::Cluster>`, to ensure the negative margin does not introduce any scrollbars.
This should generally not change anything, except if you relied on applying outer-margin type classes to the cluster, like:

```hbs
<Layout::Cluster class='margin-left-10'>
```

Which you shouldn't be doing anyhow. The splattributes `...attributes` are applied to the _inner_ cluster element now - the markup being:

```html
<div class='layout-cluster-wrapper'>
  <div class='layout-cluster' ...attributes>
    <div class='layout-cluster-item'><div>
  </div>
</div>
```

For most cases, this should not actually break/change anything.