### PR TITLE
feat: Add `@verticalAlign='stretch'` option to cluster

### DIFF
--- a/addon/components/layout/cluster.hbs
+++ b/addon/components/layout/cluster.hbs
@@ -15,6 +15,7 @@
       (layout-class-if @noWrap true 'layout-cluster--no-wrap')
       (layout-class-if @verticalAlign 'top' 'layout-cluster--top')
       (layout-class-if @verticalAlign 'bottom' 'layout-cluster--bottom')
+      (layout-class-if @verticalAlign 'stretch' 'layout-cluster--stretch')
     }}
     ...attributes
   >

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -111,6 +111,10 @@
   align-items: flex-end;
 }
 
+.layout-cluster--stretch {
+  align-items: stretch;
+}
+
 .layout-cluster--xsmall {
   --cluster-gap-size: calc(var(--layout-cluster-gap) * 0.25);
 }

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -26,6 +26,7 @@ body {
   border-radius: 3px;
   padding: 10px;
   background: rgba(255, 0, 0, 0.025);
+  height: 100%;
 }
 
 .config-option-label {

--- a/tests/dummy/app/templates/cluster.hbs
+++ b/tests/dummy/app/templates/cluster.hbs
@@ -81,7 +81,7 @@
                 @label='@verticalAlign'
                 @value={{this.clusterVerticalAlign}}
                 @onChange={{fn this.updateProperty 'clusterVerticalAlign'}}
-                @options={{array 'top' 'bottom'}}
+                @options={{array 'top' 'bottom' 'stretch'}}
               />
             </Item>
           </Layout::Cluster>

--- a/tests/integration/components/layout/cluster-test.js
+++ b/tests/integration/components/layout/cluster-test.js
@@ -105,6 +105,7 @@ module('Integration | Component | layout/cluster', function (hooks) {
     [
       { verticalAlign: 'top', className: 'layout-cluster--top' },
       { verticalAlign: 'bottom', className: 'layout-cluster--bottom' },
+      { verticalAlign: 'stretch', className: 'layout-cluster--stretch' },
     ].forEach((scenario) => {
       test(`it works with ${scenario.verticalAlign}`, async function (assert) {
         this.verticalAlign = scenario.verticalAlign;


### PR DESCRIPTION
Add a new option `stretch` for `<Layout::Cluster @verticalAlign='stretch'>`, which provides this behavior:

![Screenshot from 2020-10-27 08-44-37](https://user-images.githubusercontent.com/2411343/97271372-c2c32d80-1830-11eb-9734-75e1bf2c0400.png)

compared to the default behavior:

![Screenshot from 2020-10-27 08-44-32](https://user-images.githubusercontent.com/2411343/97271388-c8207800-1830-11eb-8699-040dd70cba5c.png)
