### PR TITLE
Rename `@size` to `@gap` for cluster & vertical stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ember install ember-layout-components
 
 ```hbs
 <Layout::Wrapper>
-  <Layout::VerticalStack @size="large" as |Section|>
+  <Layout::VerticalStack @gap="large" as |Section|>
     <Section>
       First section goes here.
     </Section>

--- a/addon/components/layout/cluster.hbs
+++ b/addon/components/layout/cluster.hbs
@@ -1,3 +1,10 @@
+{{layout-deprecate
+  '@size is deprecated, use @gap instead'
+  (if @size false true)
+  id='ember-layout-components.cluster-size'
+  until='0.10.0'
+}}
+
 <div class='layout-cluster-wrapper'>
   <div
     class={{
@@ -5,6 +12,10 @@
       'layout-cluster'
       (layout-class-if @position 'right' 'layout-cluster--right')
       (layout-class-if @position 'spaced' 'layout-cluster--spaced')
+      (layout-class-if @gap 'xsmall' 'layout-cluster--xsmall')
+      (layout-class-if @gap 'small' 'layout-cluster--small')
+      (layout-class-if @gap 'large' 'layout-cluster--large')
+      (layout-class-if @gap 'xlarge' 'layout-cluster--xlarge')
       (layout-class-if @size 'xsmall' 'layout-cluster--xsmall')
       (layout-class-if @size 'small' 'layout-cluster--small')
       (layout-class-if @size 'large' 'layout-cluster--large')

--- a/addon/components/layout/vertical-stack.hbs
+++ b/addon/components/layout/vertical-stack.hbs
@@ -1,15 +1,27 @@
+{{layout-deprecate
+  '@size is deprecated, use @gap instead'
+  (if @size false true)
+  id='ember-layout-components.vertical-stack-size'
+  until='0.10.0'
+}}
+
 <div
-  class={{layout-join-classes
-    "layout-vertical-stack"
-    (layout-class-if @size "xlarge" "layout-vertical-stack--xlarge")
-    (layout-class-if @size "large" "layout-vertical-stack--large")
-    (layout-class-if @size "small" "layout-vertical-stack--small")
-    (layout-class-if @size "xsmall" "layout-vertical-stack--xsmall")
-    (layout-class-if @withSeparator true "layout-vertical-stack--with-separator")
+  class={{
+    layout-join-classes
+    'layout-vertical-stack'
+    (layout-class-if @size 'xlarge' 'layout-vertical-stack--xlarge')
+    (layout-class-if @size 'large' 'layout-vertical-stack--large')
+    (layout-class-if @size 'small' 'layout-vertical-stack--small')
+    (layout-class-if @size 'xsmall' 'layout-vertical-stack--xsmall')
+    (layout-class-if @gap 'xlarge' 'layout-vertical-stack--xlarge')
+    (layout-class-if @gap 'large' 'layout-vertical-stack--large')
+    (layout-class-if @gap 'small' 'layout-vertical-stack--small')
+    (layout-class-if @gap 'xsmall' 'layout-vertical-stack--xsmall')
+    (layout-class-if
+      @withSeparator true 'layout-vertical-stack--with-separator'
+    )
   }}
   ...attributes
 >
-  {{yield
-    (component 'layout/vertical-stack/item')
-  }}
+  {{yield (component 'layout/vertical-stack/item')}}
 </div>

--- a/addon/helpers/layout-deprecate.js
+++ b/addon/helpers/layout-deprecate.js
@@ -1,0 +1,9 @@
+import { helper } from '@ember/component/helper';
+import { deprecate } from '@ember/debug';
+
+export default helper(function layoutDeprecate(
+  [message, testExpression],
+  options
+) {
+  deprecate(message, testExpression, options);
+});

--- a/app/helpers/layout-deprecate.js
+++ b/app/helpers/layout-deprecate.js
@@ -1,0 +1,4 @@
+export {
+  default,
+  layoutDeprecate,
+} from 'ember-layout-components/helpers/layout-deprecate';

--- a/tests/dummy/app/components/header-bar.hbs
+++ b/tests/dummy/app/components/header-bar.hbs
@@ -1,5 +1,5 @@
 <header class='header'>
-  <Layout::Cluster @size='xlarge' as |OuterItem|>
+  <Layout::Cluster @gap='xlarge' as |OuterItem|>
     <OuterItem>
       <LinkTo @route='index' class='header-logo-link'>
         ember-layout-components
@@ -8,7 +8,7 @@
 
     <OuterItem>
       <nav>
-        <Layout::Cluster @size='large' as |Item|>
+        <Layout::Cluster @gap='large' as |Item|>
           <Item>
             <LinkTo @route='cluster' class='main-nav-item'>
               Cluster

--- a/tests/dummy/app/controllers/cluster.js
+++ b/tests/dummy/app/controllers/cluster.js
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class ClusterController extends Controller {
-  @tracked clusterSize;
+  @tracked clusterGap;
   @tracked clusterPosition;
   @tracked clusterVerticalAlign;
   @tracked clusterFullWidthOnMobile;

--- a/tests/dummy/app/controllers/vertical-stack.js
+++ b/tests/dummy/app/controllers/vertical-stack.js
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class VerticalStackController extends Controller {
-  @tracked verticalStackSize;
+  @tracked verticalStackGap;
   @tracked verticalStackWithSeparator;
 
   @action

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,4 +1,4 @@
-<Layout::VerticalStack @size='large' as |Item|>
+<Layout::VerticalStack @gap='large' as |Item|>
   <Item>
     <HeaderBar />
   </Item>

--- a/tests/dummy/app/templates/center.hbs
+++ b/tests/dummy/app/templates/center.hbs
@@ -1,5 +1,5 @@
 <Layout::Wrapper>
-  <Layout::VerticalStack @size='xlarge' as |SectionItem|>
+  <Layout::VerticalStack @gap='xlarge' as |SectionItem|>
     <SectionItem>
       <h1>
         Center

--- a/tests/dummy/app/templates/cluster.hbs
+++ b/tests/dummy/app/templates/cluster.hbs
@@ -1,5 +1,5 @@
 <Layout::Wrapper>
-  <Layout::VerticalStack @size='xlarge' as |SectionItem|>
+  <Layout::VerticalStack @gap='xlarge' as |SectionItem|>
     <SectionItem>
       <h1>
         Cluster
@@ -42,9 +42,9 @@
           <Layout::Cluster @fullWidthOnMobile={{true}} as |Item|>
             <Item>
               <ConfigOption
-                @label='@size'
-                @value={{this.clusterSize}}
-                @onChange={{fn this.updateProperty 'clusterSize'}}
+                @label='@gap'
+                @value={{this.clusterGap}}
+                @onChange={{fn this.updateProperty 'clusterGap'}}
                 @options={{array 'xsmall' 'small' 'large' 'xlarge'}}
               />
             </Item>
@@ -89,7 +89,7 @@
 
         <StackItem>
           <Layout::Cluster
-            @size={{this.clusterSize}}
+            @gap={{this.clusterGap}}
             @position={{this.clusterPosition}}
             @verticalAlign={{this.clusterVerticalAlign}}
             @fullWidthOnMobile={{this.clusterFullWidthOnMobile}}
@@ -133,7 +133,7 @@
         </StackItem>
         <StackItem>
           <Layout::Cluster
-            @size={{this.clusterSize}}
+            @gap={{this.clusterGap}}
             @position={{this.clusterPosition}}
             @fullWidthOnMobile={{this.clusterFullWidthOnMobile}} as |Item|
           >
@@ -166,7 +166,7 @@
 
         <StackItem>
           <Layout::Cluster
-            @size={{this.clusterSize}}
+            @gap={{this.clusterGap}}
             @position={{this.clusterPosition}}
             @fullWidthOnMobile={{this.clusterFullWidthOnMobile}} as |Item|
           >
@@ -199,7 +199,7 @@
 
         <StackItem>
           <Layout::Cluster
-            @size={{this.clusterSize}}
+            @gap={{this.clusterGap}}
             @position={{this.clusterPosition}}
             @fullWidthOnMobile={{this.clusterFullWidthOnMobile}} as |Item|
           >

--- a/tests/dummy/app/templates/grid.hbs
+++ b/tests/dummy/app/templates/grid.hbs
@@ -1,5 +1,5 @@
 <Layout::Wrapper>
-  <Layout::VerticalStack @size='xlarge' as |SectionItem|>
+  <Layout::VerticalStack @gap='xlarge' as |SectionItem|>
     <SectionItem>
       <h1>
         Grid

--- a/tests/dummy/app/templates/vertical-stack.hbs
+++ b/tests/dummy/app/templates/vertical-stack.hbs
@@ -1,5 +1,5 @@
 <Layout::Wrapper>
-  <Layout::VerticalStack @size='xlarge' as |SectionItem|>
+  <Layout::VerticalStack @gap='xlarge' as |SectionItem|>
     <SectionItem>
       <h1>
         Vertical Stack
@@ -42,9 +42,9 @@
           <Layout::Cluster @fullWidthOnMobile={{true}} as |Item|>
             <Item>
               <ConfigOption
-                @label='@size'
-                @value={{this.verticalStackSize}}
-                @onChange={{fn this.updateProperty 'verticalStackSize'}}
+                @label='@gap'
+                @value={{this.verticalStackGap}}
+                @onChange={{fn this.updateProperty 'verticalStackGap'}}
                 @options={{array 'xsmall' 'small' 'large' 'xlarge'}}
               />
             </Item>
@@ -64,7 +64,7 @@
 
         <StackItem>
           <Layout::VerticalStack
-            @size={{this.verticalStackSize}}
+            @gap={{this.verticalStackGap}}
             @withSeparator={{this.verticalStackWithSeparator}} as |Item|
           >
             <Item>

--- a/tests/dummy/app/templates/wrapper.hbs
+++ b/tests/dummy/app/templates/wrapper.hbs
@@ -1,5 +1,5 @@
 <Layout::Wrapper>
-  <Layout::VerticalStack @size='xlarge' as |SectionItem|>
+  <Layout::VerticalStack @gap='xlarge' as |SectionItem|>
     <SectionItem>
       <h1>
         Wrapper

--- a/tests/integration/components/layout/cluster-test.js
+++ b/tests/integration/components/layout/cluster-test.js
@@ -83,6 +83,26 @@ module('Integration | Component | layout/cluster', function (hooks) {
     });
   });
 
+  module('@gap', function () {
+    [
+      { gap: 'xsmall', className: 'layout-cluster--xsmall' },
+      { gap: 'small', className: 'layout-cluster--small' },
+      { gap: 'large', className: 'layout-cluster--large' },
+      { gap: 'xlarge', className: 'layout-cluster--xlarge' },
+    ].forEach((scenario) => {
+      test(`it works with ${scenario.gap}`, async function (assert) {
+        this.gap = scenario.gap;
+
+        await render(hbs`
+          <Layout::Cluster @gap={{this.gap}}>
+          </Layout::Cluster>
+        `);
+
+        assert.dom('.layout-cluster').hasClass(scenario.className);
+      });
+    });
+  });
+
   module('@position', function () {
     [
       { position: 'right', className: 'layout-cluster--right' },

--- a/tests/integration/components/layout/vertical-stack-test.js
+++ b/tests/integration/components/layout/vertical-stack-test.js
@@ -51,6 +51,26 @@ module('Integration | Component | layout/vertical-stack', function (hooks) {
     });
   });
 
+  module('@gap', function () {
+    [
+      { gap: 'xsmall', className: 'layout-vertical-stack--xsmall' },
+      { gap: 'small', className: 'layout-vertical-stack--small' },
+      { gap: 'large', className: 'layout-vertical-stack--large' },
+      { gap: 'xlarge', className: 'layout-vertical-stack--xlarge' },
+    ].forEach((scenario) => {
+      test(`it works with ${scenario.gap}`, async function (assert) {
+        this.gap = scenario.gap;
+
+        await render(hbs`
+          <Layout::VerticalStack @gap={{this.gap}}>
+          </Layout::VerticalStack>
+        `);
+
+        assert.dom('.layout-vertical-stack').hasClass(scenario.className);
+      });
+    });
+  });
+
   module('@withSeparator', function () {
     [
       {


### PR DESCRIPTION
As the naming `@size` is actually not really correct and maybe a bit misleading.

For now, `@size` will still work (but show a deprecation message). It will be removed in the next release (probably 0.10.0).