### PR TITLE
feat: Import from `@ember/template` instead of `@ember/string`

### DIFF
--- a/addon/helpers/layout-css-var.js
+++ b/addon/helpers/layout-css-var.js
@@ -1,5 +1,5 @@
 import { helper } from '@ember/component/helper';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import { isNone } from '@ember/utils';
 
 export default helper(function layoutCssVar(_, hash) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.23.1",
-    "ember-cli-htmlbars": "^5.3.2"
+    "ember-cli-htmlbars": "^5.6.2"
   },
   "devDependencies": {
     "@ember/optional-features": "~2.0.0",

--- a/tests/dummy/app/components/demo-item.js
+++ b/tests/dummy/app/components/demo-item.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 const TEXTS = [
   'one text',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5448,7 +5448,7 @@ ember-cli-htmlbars@^5.2.0, ember-cli-htmlbars@^5.3.1:
     strip-bom "^4.0.0"
     walk-sync "^2.2.0"
 
-ember-cli-htmlbars@^5.3.2:
+ember-cli-htmlbars@^5.6.2:
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-5.6.2.tgz#01aebe6df7b8db7fd6e5dd02ba1c82898c087a35"
   integrity sha512-8+x82oVqSkWN1RkHtK7QG40D/X94uEJCPmv5QUOJDg4KE+F/zrjA8TEjDKI/phjBUS6JfZ+Hg5RvamU1ZoZbjQ==


### PR DESCRIPTION
As the latter has been deprecated in ember 3.25.x