### PR TITLE
feat: Add none option for gap size

### DIFF
--- a/addon/components/layout/cluster.hbs
+++ b/addon/components/layout/cluster.hbs
@@ -5,10 +5,12 @@
       'layout-cluster'
       (layout-class-if @position 'right' 'layout-cluster--right')
       (layout-class-if @position 'spaced' 'layout-cluster--spaced')
+      (layout-class-if @gap 'none' 'layout-cluster--no-gap')
       (layout-class-if @gap 'xsmall' 'layout-cluster--xsmall')
       (layout-class-if @gap 'small' 'layout-cluster--small')
       (layout-class-if @gap 'large' 'layout-cluster--large')
       (layout-class-if @gap 'xlarge' 'layout-cluster--xlarge')
+      (layout-class-if @gapVertical 'none' 'layout-cluster--vertical-no-gap')
       (layout-class-if @gapVertical 'xsmall' 'layout-cluster--vertical-xsmall')
       (layout-class-if @gapVertical 'small' 'layout-cluster--vertical-small')
       (layout-class-if @gapVertical 'medium' 'layout-cluster--vertical-medium')

--- a/addon/components/layout/stack.hbs
+++ b/addon/components/layout/stack.hbs
@@ -6,10 +6,11 @@
     (layout-class-if @size 'large' 'layout-stack--large')
     (layout-class-if @size 'small' 'layout-stack--small')
     (layout-class-if @size 'xsmall' 'layout-stack--xsmall')
-    (layout-class-if @gap 'xlarge' 'layout-stack--xlarge')
-    (layout-class-if @gap 'large' 'layout-stack--large')
-    (layout-class-if @gap 'small' 'layout-stack--small')
+    (layout-class-if @gap 'none' 'layout-stack--no-gap')
     (layout-class-if @gap 'xsmall' 'layout-stack--xsmall')
+    (layout-class-if @gap 'small' 'layout-stack--small')
+    (layout-class-if @gap 'large' 'layout-stack--large')
+    (layout-class-if @gap 'xlarge' 'layout-stack--xlarge')
     (layout-class-if @withSeparator true 'layout-stack--with-separator')
   }}
   ...attributes

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -46,6 +46,10 @@
   margin-bottom: var(--stack-gap-size);
 }
 
+.layout-stack--no-gap {
+  --stack-gap-size: 0rem;
+}
+
 .layout-stack--xsmall {
   --stack-gap-size: calc(var(--layout-stack-gap) * 0.25);
 }
@@ -116,6 +120,10 @@
   align-items: stretch;
 }
 
+.layout-cluster--no-gap {
+  --cluster-gap-size: 0rem;
+}
+
 .layout-cluster--xsmall {
   --cluster-gap-size: calc(var(--layout-cluster-gap) * 0.25);
 }
@@ -130,6 +138,10 @@
 
 .layout-cluster--xlarge {
   --cluster-gap-size: calc(var(--layout-cluster-gap) * 4);
+}
+
+.layout-cluster--vertical-no-gap {
+  --cluster-vertical-gap-size: 0rem;
 }
 
 .layout-cluster--vertical-xsmall {

--- a/tests/dummy/app/templates/cluster.hbs
+++ b/tests/dummy/app/templates/cluster.hbs
@@ -62,7 +62,7 @@
                 @label='@gap'
                 @value={{this.clusterGap}}
                 @onChange={{fn this.updateProperty 'clusterGap'}}
-                @options={{array 'xsmall' 'small' 'large' 'xlarge'}}
+                @options={{array 'none' 'xsmall' 'small' 'large' 'xlarge'}}
               />
             </Item>
 
@@ -71,7 +71,9 @@
                 @label='@gapVertical'
                 @value={{this.clusterGapVertical}}
                 @onChange={{fn this.updateProperty 'clusterGapVertical'}}
-                @options={{array 'xsmall' 'small' 'medium' 'large' 'xlarge'}}
+                @options={{
+                  array 'none' 'xsmall' 'small' 'medium' 'large' 'xlarge'
+                }}
               />
             </Item>
 

--- a/tests/dummy/app/templates/stack.hbs
+++ b/tests/dummy/app/templates/stack.hbs
@@ -47,7 +47,7 @@
                 @label='@gap'
                 @value={{this.stackGap}}
                 @onChange={{fn this.updateProperty 'stackGap'}}
-                @options={{array 'xsmall' 'small' 'large' 'xlarge'}}
+                @options={{array 'none' 'xsmall' 'small' 'large' 'xlarge'}}
               />
             </Item>
 
@@ -55,9 +55,7 @@
               <ConfigOption
                 @label='@withSeparator'
                 @value={{this.stackWithSeparator}}
-                @onChange={{
-                  fn this.updateProperty 'stackWithSeparator'
-                }}
+                @onChange={{fn this.updateProperty 'stackWithSeparator'}}
                 @options={{array true}}
               />
             </Item>

--- a/tests/integration/components/layout/cluster-test.js
+++ b/tests/integration/components/layout/cluster-test.js
@@ -66,6 +66,7 @@ module('Integration | Component | layout/cluster', function (hooks) {
 
   module('@gap', function () {
     [
+      { gap: 'none', className: 'layout-cluster--no-gap' },
       { gap: 'xsmall', className: 'layout-cluster--xsmall' },
       { gap: 'small', className: 'layout-cluster--small' },
       { gap: 'large', className: 'layout-cluster--large' },
@@ -86,6 +87,7 @@ module('Integration | Component | layout/cluster', function (hooks) {
 
   module('@gapVertical', function () {
     [
+      { gapVertical: 'none', className: 'layout-cluster--vertical-no-gap' },
       { gapVertical: 'xsmall', className: 'layout-cluster--vertical-xsmall' },
       { gapVertical: 'small', className: 'layout-cluster--vertical-small' },
       { gapVertical: 'medium', className: 'layout-cluster--vertical-medium' },

--- a/tests/integration/components/layout/stack-test.js
+++ b/tests/integration/components/layout/stack-test.js
@@ -33,6 +33,7 @@ module('Integration | Component | layout/stack', function (hooks) {
 
   module('@gap', function () {
     [
+      { gap: 'none', className: 'layout-stack--no-gap' },
       { gap: 'xsmall', className: 'layout-stack--xsmall' },
       { gap: 'small', className: 'layout-stack--small' },
       { gap: 'large', className: 'layout-stack--large' },


### PR DESCRIPTION
For both `<Layout::Stack>` as well as `<Layout::Cluster>` you can now define `@gap='none'`.