### PR TITLE
chore: Add forgotten deprecation for Stack `@size`

### DIFF
--- a/addon/components/layout/stack.hbs
+++ b/addon/components/layout/stack.hbs
@@ -1,3 +1,10 @@
+{{layout-deprecate
+  '<Layout::Stack>: You have to use @gap instead of @size'
+  @size
+  id='ember-layout-components.gap-instead-of-size'
+  until='2.0.0'
+  for='ember-layout-components'
+}}
 <div
   class={{
     layout-join-classes


### PR DESCRIPTION
This should have been removed before 1.0.0, but got forgotten. Will be removed in 2.0.0!