### PR TITLE
feat: Use flex gap for Cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Based on [every-layout.dev](https://every-layout.dev/).
 - Ember CLI v3.20 or above
 - Node.js v10 or above
 
+This addon makes use of some modern CSS features, which means that browser support might be limited:
+
+- It makes heavy use of runtime CSS Variables, which means it will not work in IE11
+- The Cluster uses [flex gap](https://caniuse.com/flexbox-gap), which is supported in all modern browsers (Safari 14.1+). There is an included fallback behavior for browsers that do not support it.
+
 ## Installation
 
 ```
@@ -27,7 +32,7 @@ ember install ember-layout-components
 
 ```hbs
 <Layout::Wrapper>
-  <Layout::Stack @gap="large" as |Section|>
+  <Layout::Stack @gap='large' as |Section|>
     <Section>
       First section goes here.
     </Section>

--- a/addon/components/layout/cluster.hbs
+++ b/addon/components/layout/cluster.hbs
@@ -1,32 +1,42 @@
-<div class='layout-cluster-wrapper {{@wrapperClasses}}'>
-  <div
-    class={{
-      layout-join-classes
-      'layout-cluster'
-      (layout-class-if @position 'right' 'layout-cluster--right')
-      (layout-class-if @position 'spaced' 'layout-cluster--spaced')
-      (layout-class-if @position 'center' 'layout-cluster--center')
-      (layout-class-if @gap 'none' 'layout-cluster--no-gap')
-      (layout-class-if @gap 'xsmall' 'layout-cluster--xsmall')
-      (layout-class-if @gap 'small' 'layout-cluster--small')
-      (layout-class-if @gap 'large' 'layout-cluster--large')
-      (layout-class-if @gap 'xlarge' 'layout-cluster--xlarge')
-      (layout-class-if @gapVertical 'none' 'layout-cluster--vertical-no-gap')
-      (layout-class-if @gapVertical 'xsmall' 'layout-cluster--vertical-xsmall')
-      (layout-class-if @gapVertical 'small' 'layout-cluster--vertical-small')
-      (layout-class-if @gapVertical 'medium' 'layout-cluster--vertical-medium')
-      (layout-class-if @gapVertical 'large' 'layout-cluster--vertical-large')
-      (layout-class-if @gapVertical 'xlarge' 'layout-cluster--vertical-xlarge')
-      (layout-class-if
-        @fullWidthOnMobile true 'layout-cluster--full-width-on-mobile'
-      )
-      (layout-class-if @noWrap true 'layout-cluster--no-wrap')
-      (layout-class-if @verticalAlign 'top' 'layout-cluster--top')
-      (layout-class-if @verticalAlign 'bottom' 'layout-cluster--bottom')
-      (layout-class-if @verticalAlign 'stretch' 'layout-cluster--stretch')
-    }}
-    ...attributes
-  >
-    {{yield (component 'layout/cluster/item')}}
-  </div>
+{{layout-deprecate
+  '<Layout::Cluster>: @wrapperClasses is not used anymore, the wrapper element is gone.'
+  (if @wrapperClasses false true)
+  id='ember-layout-components.cluster-wrapper-classes'
+  until='2.1.0'
+  since='2.0.0'
+  for='ember-layout-components'
+}}
+
+<div
+  class={{
+    layout-join-classes
+    'layout-cluster'
+    (layout-class-if @position 'right' 'layout-cluster--right')
+    (layout-class-if @position 'spaced' 'layout-cluster--spaced')
+    (layout-class-if @position 'center' 'layout-cluster--center')
+    (layout-class-if @gap 'none' 'layout-cluster--no-gap')
+    (layout-class-if @gap 'xsmall' 'layout-cluster--xsmall')
+    (layout-class-if @gap 'small' 'layout-cluster--small')
+    (layout-class-if @gap 'large' 'layout-cluster--large')
+    (layout-class-if @gap 'xlarge' 'layout-cluster--xlarge')
+    (layout-class-if @gapVertical 'none' 'layout-cluster--vertical-no-gap')
+    (layout-class-if @gapVertical 'xsmall' 'layout-cluster--vertical-xsmall')
+    (layout-class-if @gapVertical 'small' 'layout-cluster--vertical-small')
+    (layout-class-if @gapVertical 'medium' 'layout-cluster--vertical-medium')
+    (layout-class-if @gapVertical 'large' 'layout-cluster--vertical-large')
+    (layout-class-if @gapVertical 'xlarge' 'layout-cluster--vertical-xlarge')
+    (layout-class-if
+      @fullWidthOnMobile true 'layout-cluster--full-width-on-mobile'
+    )
+    (layout-class-if @noWrap true 'layout-cluster--no-wrap')
+    (layout-class-if @verticalAlign 'top' 'layout-cluster--top')
+    (layout-class-if @verticalAlign 'bottom' 'layout-cluster--bottom')
+    (layout-class-if @verticalAlign 'stretch' 'layout-cluster--stretch')
+    (layout-class-if
+      (layout-has-flex-gap-support) false 'layout-cluster--no-gap-support'
+    )
+  }}
+  ...attributes
+>
+  {{yield (component 'layout/cluster/item')}}
 </div>

--- a/addon/helpers/layout-has-flex-gap-support.js
+++ b/addon/helpers/layout-has-flex-gap-support.js
@@ -1,0 +1,38 @@
+import { helper } from '@ember/component/helper';
+
+// Cache this here, to ensure we only run the check once
+let isSupported = undefined;
+
+export default helper(function layoutHasFlexGapSupport() {
+  return checkFlexGapIsSupported();
+});
+
+// Taken from: https://ishadeed.com/article/flexbox-gap/
+function checkFlexGapIsSupported() {
+  if (typeof isSupported === 'boolean') {
+    return isSupported;
+  }
+
+  // create flex container with row-gap set
+  let flex = document.createElement('div');
+  flex.style.display = 'flex';
+  flex.style.flexDirection = 'column';
+  flex.style.rowGap = '1px';
+
+  // create two, elements inside it
+  flex.appendChild(document.createElement('div'));
+  flex.appendChild(document.createElement('div'));
+
+  // append to the DOM (needed to obtain scrollHeight)
+  document.body.appendChild(flex);
+  isSupported = flex.scrollHeight === 1; // flex container should be 1px high from the row-gap
+
+  flex.parentNode.removeChild(flex);
+
+  return isSupported;
+}
+
+// This is exported here so we can test this
+export function _setIsSupported(_isSupported) {
+  isSupported = _isSupported;
+}

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -72,32 +72,31 @@
 }
 
 /* Cluster */
-.layout-cluster-wrapper {
-  /* ↓ Suppress horizontal scrolling caused by the negative margin in some circumstances */
-  overflow: hidden;
-}
-
-/* Without this, the overflow: hidden; would not work, sometimes showing unexpected scrollbars... */
 .layout-cluster {
   --cluster-gap-size: var(--layout-cluster-gap);
-  --cluster-horizontal-gap: calc(var(--cluster-gap-size) / 2);
-  --cluster-vertical-gap: calc(
-    var(--cluster-vertical-gap-size, var(--cluster-gap-size)) / 2
+  --cluster-horizontal-gap: var(--cluster-gap-size);
+  --cluster-vertical-gap: var(
+    --cluster-vertical-gap-size,
+    var(--cluster-gap-size)
   );
 
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  margin: calc(var(--cluster-vertical-gap) * -1)
-    calc(var(--cluster-horizontal-gap) * -1);
+  gap: var(--cluster-vertical-gap) var(--cluster-horizontal-gap);
 }
 
 .layout-cluster--no-wrap {
   flex-wrap: nowrap;
 }
 
-.layout-cluster-item {
-  margin: var(--cluster-vertical-gap) var(--cluster-horizontal-gap);
+.layout-cluster--no-gap-support {
+  gap: 0;
+}
+
+.layout-cluster--no-gap-support .layout-cluster-item {
+  margin: calc(var(--cluster-vertical-gap) / 2)
+    calc(var(--cluster-horizontal-gap) / 2);
 }
 
 .layout-cluster--right {
@@ -173,18 +172,19 @@
 }
 
 /* "Floating" is achieved via margin: auto */
-.layout-cluster-item--left {
+/* We have to also add the no-gap-support child declaration to ensure it has a high enough specifity */
+.layout-cluster-item--left,
+.layout-cluster--no-gap-support > .layout-cluster-item--left {
   margin-right: auto;
 }
 
-.layout-cluster-item--right {
+.layout-cluster-item--right,
+.layout-cluster--no-gap-support > .layout-cluster-item--right {
   margin-left: auto;
 }
 
 @media all and (max-width: 420px) {
   .layout-cluster--full-width-on-mobile {
-    margin-left: 0;
-    margin-right: 0;
     flex-wrap: wrap;
   }
 

--- a/app/helpers/layout-has-flex-gap-support.js
+++ b/app/helpers/layout-has-flex-gap-support.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-layout-components/helpers/layout-has-flex-gap-support';

--- a/tests/dummy/app/templates/cluster.hbs
+++ b/tests/dummy/app/templates/cluster.hbs
@@ -34,10 +34,17 @@
       </p>
 
       <p>
-        Any splattributes will be added to the inner flexbox container. 
-        If you need to add classes to the wrapper, you can do so via
-        <CodeInline @code="@wrapperClasses='outer-class'" />
-        .
+        Any splattributes will be added to the flexbox container.
+      </p>
+
+      <p>
+        Note that the Cluster uses 
+        <a href='https://caniuse.com/flexbox-gap'>flex gap</a>, 
+        which might not be supported in all browsers.
+        Coverage is pretty good nowadays, but especially Safari &lt;= 14 do not support it. 
+        For these browsers, a fallback is provided that handles the spacing via margins. 
+        This should be serviceable, but please do note that in those cases there will be an outer spacing due to the limitations
+        of this approach. It should still serve as an acceptable fallback behavior in the spirit of progressive enhancement, though.
       </p>
     </SectionItem>
 

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -5,13 +5,11 @@
 
   <p>
     This addon provides easy to use and flexible layout components.
-          By using these components, your layout will automatically be flexible and consistent.
-          Instead of defining exactly how something should look like at a given viewport, let the intrinsic size of
-          content and CSS calcualte the best possible layout, based on the basic rules these layout components define.
-          This addon is heavily inspired by
-    <a href='https://every-layout.dev/'>
-      every-layout.dev
-    </a>
+    By using these components, your layout will automatically be flexible and consistent.
+    Instead of defining exactly how something should look like at a given viewport, let the intrinsic size of
+    content and CSS calcualte the best possible layout, based on the basic rules these layout components define.
+    This addon is heavily inspired by
+    <a href='https://every-layout.dev/'>every-layout.dev</a>.
   </p>
 
   <h2>
@@ -20,11 +18,15 @@
 
   <p>
     All layout components use CSS Properties. If you need to support IE11, you could use something like
-    <a href='https://github.com/MadLittleMods/postcss-css-variables'>
-      postcss-css-variables
-    </a>
-    to get a gracious
-          fallback.
+    <a href='https://github.com/MadLittleMods/postcss-css-variables'>postcss-css-variables</a>
+    to get a gracious fallback.
+  </p>
+
+  <p>
+    The Cluster uses 
+    <a href='https://caniuse.com/flexbox-gap'>flex gap</a>, 
+    which is supported in all modern browsers (Safari 14.1+). 
+    There is an included fallback behavior for browsers that do not support it.
   </p>
 
   <h2>

--- a/tests/integration/components/layout/cluster-test.js
+++ b/tests/integration/components/layout/cluster-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { _setIsSupported } from 'ember-layout-components/helpers/layout-has-flex-gap-support';
 
 module('Integration | Component | layout/cluster', function (hooks) {
   setupRenderingTest(hooks);
@@ -22,12 +23,11 @@ module('Integration | Component | layout/cluster', function (hooks) {
 
   test('it allows to add HTML attributes', async function (assert) {
     await render(hbs`
-      <Layout::Cluster class="my-class" @wrapperClasses='wrapper-class' as |Item|>
+      <Layout::Cluster class="my-class" as |Item|>
       <Item class="item-class"></Item>
       </Layout::Cluster>
     `);
 
-    assert.dom('.layout-cluster-wrapper').hasClass('wrapper-class');
     assert.dom('.layout-cluster').hasClass('my-class');
     assert.dom('.layout-cluster-item').hasClass('item-class');
   });
@@ -218,6 +218,37 @@ module('Integration | Component | layout/cluster', function (hooks) {
       `);
 
       assert.dom('.layout-cluster').hasClass('layout-cluster--no-wrap');
+    });
+  });
+
+  module('flex gap support', function (hooks) {
+    hooks.afterEach(function () {
+      // Reset it so it can be calculated correctly again
+      _setIsSupported(undefined);
+    });
+
+    test('it works with flex gap support', async function (assert) {
+      _setIsSupported(true);
+
+      await render(hbs`
+        <Layout::Cluster>
+        </Layout::Cluster>
+      `);
+
+      assert
+        .dom('.layout-cluster')
+        .doesNotHaveClass('layout-cluster--no-gap-support');
+    });
+
+    test('it works without flex gap support', async function (assert) {
+      _setIsSupported(false);
+
+      await render(hbs`
+        <Layout::Cluster>
+        </Layout::Cluster>
+      `);
+
+      assert.dom('.layout-cluster').hasClass('layout-cluster--no-gap-support');
     });
   });
 });

--- a/tests/integration/helpers/layout-has-flex-gap-support-test.js
+++ b/tests/integration/helpers/layout-has-flex-gap-support-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | layout-has-flex-gap-support', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it works', async function (assert) {
+    await render(hbs`
+    {{#let (layout-has-flex-gap-support) as |hasSupport|}}
+      {{hasSupport}}
+    {{/let}}`);
+
+    assert.dom(this.element).hasText('true');
+  });
+});


### PR DESCRIPTION
BREAKING CHANGE: This is a breaking change, as it removes the outer wrapper and thus changes the shape of the HTML that is emitted.

Changes required:
* If you had set `@wrapperClasses` on a `<Layout::Cluster>` anywhere, you'll have to refactor this to instead set it directly as `class=''`, as the outer wrapper element is gone.
* If you have relied on the wrapper element for some reason, you might need to double check everything still looks good. This _should not_ really be the case much.

It is a much cleaner/nicer solution though, and supported in all modern browers ([supported by Safari 14.1+](https://caniuse.com/flexbox-gap)).

There is a fallback behavior that is detected via JS (as it cannot be properly detected in CSS alone). The fallback will ensure there are still gaps, but importantly will _not_ use the negative-margin hack to ensure the items are flush on the outside. 

The fallback behavior should be acceptable, not perfect but workable.